### PR TITLE
Release 1.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,23 @@
 
 A button that toggles an entry's published state.
 
+
 ## Installation
 
 - Upload the `/publishbutton` folder to your Symphony `/extensions` folder.
 - Enable it by selecting "Publish Button", choose Enable from the with-selected menu, then click Apply.
 
+
 ## Usage
 
-When this field is added to a section, a new button will appear on its entries pages. This **Publish Button** will allow an author to toggle the 'published'-state of an entry between 'published' and 'unpublished'. Behind the scenes the button acts like a normal checkbox and translates these states to simple `yes` and `no` values which then can be used to filter your entries in data-sources.
+When this field is added to a section, a new button will appear on its entries pages. This **Publish Button** will allow an author to toggle the published-state of an entry between "_Published_" and "_Unpublished_". Behind the scenes the button acts like a normal checkbox and translates these states to simple `yes` and `no` values which then can be used to filter your entries in data-sources.
 
 When the user is logged in to Symphony, the value used for filtering and XML output will always be `yes`. This allows the editor to create/edit an entry (like an article) and preview it on the live site without the public seeing it.
 
+
 ## Compatibility
 
-This extension plays nicely together with the [Ajax Checkbox][1] extension _(Version 1.5.0 and up)_ which offers the possibility to easily toggle the 'published'-state directly in the 'publish index view'.
+**Publish button**  plays nicely together with the [Ajax Checkbox][1] extension _(Version 1.5.0 and up)_ which offers the possibility to easily toggle the published-state directly in the section's index/table view.
+
+
+[1]: https://github.com/DeuxHuitHuit/ajax_checkbox

--- a/README.md
+++ b/README.md
@@ -7,8 +7,12 @@ A button that toggles an entry's published state.
 - Upload the `/publishbutton` folder to your Symphony `/extensions` folder.
 - Enable it by selecting "Publish Button", choose Enable from the with-selected menu, then click Apply.
 
-When this field is added to a section, a button appears which will toggle the published state. Data-sources can be filtered with a yes or no value.
+## Usage
 
-When the user is logged in to Symphony, the value used for filtering and XML output will always be 'yes'.
+When this field is added to a section, a new button will appear on its entries pages. This **Publish Button** will allow an author to toggle the 'published'-state of an entry between 'published' and 'unpublished'. Behind the scenes the button acts like a normal checkbox and translates these states to simple `yes` and `no` values which then can be used to filter your entries in data-sources.
 
-This allows the editor to create/edit an entry (like an article), and preview it on the live site without the public seeing it.
+When the user is logged in to Symphony, the value used for filtering and XML output will always be `yes`. This allows the editor to create/edit an entry (like an article) and preview it on the live site without the public seeing it.
+
+## Compatibility
+
+This extension plays nicely together with the [Ajax Checkbox][1] extension _(Version 1.5.0 and up)_ which offers the possibility to easily toggle the 'published'-state directly in the 'publish index view'.

--- a/README.md
+++ b/README.md
@@ -1,24 +1,25 @@
 # Publish Button
 
-A button that toggles an entry's published state.
+A button that toggles an entry's published-state and allows authors to preview unpublished entries on the live site.
 
 
 ## Installation
 
 - Upload the `/publishbutton` folder to your Symphony `/extensions` folder.
-- Enable it by selecting "Publish Button", choose Enable from the with-selected menu, then click Apply.
+- Enable it by selecting 'Publish Button', choose 'Enable' from the with-selected menu, then click 'Apply'.
 
 
 ## Usage
 
 When this field is added to a section, a new button will appear on its entries pages. This **Publish Button** will allow an author to toggle the published-state of an entry between "_Published_" and "_Unpublished_". Behind the scenes the button acts like a normal checkbox and translates these states to simple `yes` and `no` values which then can be used to filter your entries in data-sources.
 
-When the user is logged in to Symphony, the value used for filtering and XML output will always be `yes`. This allows the editor to create/edit an entry (like an article) and preview it on the live site without the public seeing it.
+When the user is logged in to Symphony, the value used for filtering and XML output will always be `yes`. This allows the author to create/edit an entry (like an article) and preview it on the live site without the public seeing it.
 
 
 ## Compatibility
 
-**Publish button**  plays nicely together with the [Ajax Checkbox][1] extension _(Version 1.5.0 and up)_ which offers the possibility to easily toggle the published-state directly in the section's index/table view.
+**Publish button**  plays nicely together with the [Ajax Checkbox][2] extension _(Version 1.5.0 and up)_ which adds the possibility to easily toggle the published-state directly in the section's index/table view.
 
 
-[1]: https://github.com/DeuxHuitHuit/ajax_checkbox
+[1]: https://www.getsymphony.com
+[2]: https://github.com/DeuxHuitHuit/ajax_checkbox

--- a/assets/publishbutton.js
+++ b/assets/publishbutton.js
@@ -19,7 +19,7 @@
 
 			if (!$('#context .actions').length) $('#context #breadcrumbs').after('<ul class="actions" />');
 
-			button = $('#context .actions').append('<li><a class="pu blishbutton-trigger create button disabled">' + Symphony.Language.get('Unpublished') + '</a></li>').find('.create');
+			button = $('#context .actions').append('<li><a class="publishbutton-trigger create button disabled">' + Symphony.Language.get('Unpublished') + '</a></li>').find('.create');
 
 			if (input_state) {
 				button

--- a/extension.meta.xml
+++ b/extension.meta.xml
@@ -2,9 +2,10 @@
 <extension id="publishbutton" xmlns="http://symphony-cms.com/schemas/extension/1.0">
 	<name>Publish Button</name>
 	<description>A button that toggles an entry's published state</description>
-	<repo type="github"></repo>
+	<repo type="github">https://github.com/pixelninja/publishbutton</repo>
+	<url type="issues">https://github.com/pixelninja/publishbutton/issues/</url>
 	<types>
-		<type>Field</type>
+		<type>Workflow</type>
 	</types>
 	<authors>
 		<author>
@@ -13,12 +14,17 @@
 		</author>
 	</authors>
 	<releases>
-		<release version="1.2" date="2018-06-14" min="2.7.x">
+		<release version="1.2.1" date="2018-06-14" min="2.7.x">
+			- Added Links to the meta.xml
+			- Unified version numbers in meta.xml
+			- Extended readme
+		</release>
+		<release version="1.2.0" date="2018-06-14" min="2.7.x">
 			- Fix bug where authors and managers wouldn't see the button
 		</release>
-		<release version="1.1" date="2017-12-07" min="2.7.x">
+		<release version="1.1.0" date="2017-12-07" min="2.7.x">
 			- Make sure JS is executed after window load
 		</release>
-		<release version="1.0" date="2017-11-02" min="2.7.x" />
+		<release version="1.0.0" date="2017-11-02" min="2.7.x" />
 	</releases>
 </extension>

--- a/extension.meta.xml
+++ b/extension.meta.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <extension id="publishbutton" xmlns="http://symphony-cms.com/schemas/extension/1.0">
 	<name>Publish Button</name>
-	<description>A button that toggles an entry's published state</description>
+	<description>A button that toggles an entry's published-state and allows authors to preview unpublished entries on the live site.</description>
 	<repo type="github">https://github.com/pixelninja/publishbutton</repo>
 	<url type="issues">https://github.com/pixelninja/publishbutton/issues/</url>
 	<types>


### PR DESCRIPTION
Hey Phill,

thanks a lot for this awesome little helper! I implemented it in a current project and together with the [Ajax Checkbox](https://github.com/DeuxHuitHuit/ajax_checkbox) extension things are getting close to the "perfect publishing workflow" in Symphony :)

I just submitted [a PR](https://github.com/DeuxHuitHuit/ajax_checkbox/pull/7) that makes Ajax Checkbox officially support your extension and also added a link to this repo in the extension's readme.

As the "true powers" of this little gem seemed a little hidden to me I also tried to put some more information in the readme and added a few missing infos in the meta.xml – that's what this PR is about. Feel free to correct things if necessary – I'm not a native english speaker ;)

And it would be very cool if you could [add tags/releases](https://github.com/symphonists/symphony-extensions-network#3-extension-publishing) to your extension repos – improves finding the right version a  lot (especially on symphonyextensions.com). And adding the github-topics [`symphony-cms`](https://github.com/search?q=topic%3Asymphony-cms) and [`symphony-cms-extension`](https://github.com/search?q=topic%3Asymphony-cms-extension) would be a great move to :)

Thanks a lot & cheers from germany,
Roman

